### PR TITLE
switched off deployment for master

### DIFF
--- a/ci-cd/deploy01-settings.sh
+++ b/ci-cd/deploy01-settings.sh
@@ -32,6 +32,10 @@ if [ "$DEPLOYMENT_ENVIRONMENT" == "production" ] && [ "$TRAVIS_BRANCH" != "$TRAV
     export DEPLOYMENT_SHOULD_RUN=false
 else
 
+echo "*********************** SWITCHED OFF DEPLOYMENT IN MASTER TO NOT INTERFER WITH TESTING FROM BRANCH htw-staging-server ***************************"
+export DEPLOYMENT_SHOULD_RUN=false
+
+
 echo "TRAVIS_TAG $TRAVIS_TAG"
 if [ -z "$TRAVIS_TAG" ]; then
   export DEPLOYMENT_TAG=$TRAVIS_COMMIT


### PR DESCRIPTION
Switched off deployment in master to not interfere with testing deployment scripts from branch htw-staging-server. Will be switched back on as soon as deployment works.