### PR TITLE
Improve week validation

### DIFF
--- a/app/admin/internships.rb
+++ b/app/admin/internships.rb
@@ -67,9 +67,9 @@ ActiveAdmin.register Internship do
         row :company
         row :start_date
         row :end_date
-        row ('returnDayst') {ad.returnDays}
-        row ('weekCount') {ad.weekCount}
-        row ('weekValidation') {ad.weekValidationActAdm}
+				# TBD clean this up
+        row ('weekCount') {ad.duration.weeks}
+        row ('weekValidation') {ad.duration.weekValidationActAdm}
         row :operational_area
         row :tasks
         row :supervisor_name

--- a/app/admin/internships.rb
+++ b/app/admin/internships.rb
@@ -67,6 +67,7 @@ ActiveAdmin.register Internship do
         row :company
         row :start_date
         row :end_date
+        row ('returnDayst') {ad.returnDays}
         row ('weekCount') {ad.weekCount}
         row ('weekValidation') {ad.weekValidationActAdm}
         row :operational_area

--- a/app/models/internship.rb
+++ b/app/models/internship.rb
@@ -2,10 +2,15 @@ require 'date'
 require 'time'
 class Internship < ActiveRecord::Base
 
+
   attr_accessible :attachments_attributes, :living_costs, :orientation_id, :salary, :working_hours, :programming_language_ids, :internship_rating_id,
     :company_id, :user_id, :title, :recommend, :email_public, :semester_id, :description, :internship_report, :student_id, :start_date, :end_date, :operational_area, :tasks, :internship_state_id, :reading_prof_id, :payment_state_id, :registration_state_id, :contract_state_id, :report_state_id, :certificate_state_id, :certificate_signed_by_internship_officer, :certificate_signed_by_prof,
     :certificate_to_prof, :comment, :supervisor_email, :supervisor_name, :internship_rating_attributes, :completed
   validates :semester_id, :student, presence: true
+<<<<<<< HEAD
+=======
+
+>>>>>>> fixed week validation, proper text/translation generation still pending
 
 
   validates_presence_of :company

--- a/app/models/internship.rb
+++ b/app/models/internship.rb
@@ -7,11 +7,6 @@ class Internship < ActiveRecord::Base
     :company_id, :user_id, :title, :recommend, :email_public, :semester_id, :description, :internship_report, :student_id, :start_date, :end_date, :operational_area, :tasks, :internship_state_id, :reading_prof_id, :payment_state_id, :registration_state_id, :contract_state_id, :report_state_id, :certificate_state_id, :certificate_signed_by_internship_officer, :certificate_signed_by_prof,
     :certificate_to_prof, :comment, :supervisor_email, :supervisor_name, :internship_rating_attributes, :completed
   validates :semester_id, :student, presence: true
-<<<<<<< HEAD
-=======
-
->>>>>>> fixed week validation, proper text/translation generation still pending
-
 
   validates_presence_of :company
 

--- a/app/models/internship.rb
+++ b/app/models/internship.rb
@@ -1,3 +1,4 @@
+require 'date'
 class Internship < ActiveRecord::Base
 
   attr_accessible :attachments_attributes, :living_costs, :orientation_id, :salary, :working_hours, :programming_language_ids, :internship_rating_id,

--- a/app/models/internship.rb
+++ b/app/models/internship.rb
@@ -4,7 +4,6 @@ class Internship < ActiveRecord::Base
     :company_id, :user_id, :title, :recommend, :email_public, :semester_id, :description, :internship_report, :student_id, :start_date, :end_date, :operational_area, :tasks, :internship_state_id, :reading_prof_id, :payment_state_id, :registration_state_id, :contract_state_id, :report_state_id, :certificate_state_id, :certificate_signed_by_internship_officer, :certificate_signed_by_prof,
     :certificate_to_prof, :comment, :supervisor_email, :supervisor_name, :internship_rating_attributes, :completed
   validates :semester_id, :student, presence: true
-  #validate :start_date_before_end_date?
 
 
   validates_presence_of :company
@@ -54,63 +53,13 @@ class Internship < ActiveRecord::Base
     student.enrolment_number
   end
 
-  def start_date_before_end_date?
-    if (:start_date > :end_date)
-      errors.add :end_date, "must be after start date"
-    end
+  def duration
+    @duration || @duration = InternshipDuration.new(self)
   end
-
-  def returnDays
-    days = (self[:end_date] - self[:start_date]).to_i
-    return days;
-  end  
-
-  def weekCount
-    days = returnDays
-    weeks = days/7
-    return weeks
+  after_save do
+     @duration = nil
   end
-
-  # CodeReviewSS17: this method name gives no hint
-  # on what the method does/returns. A,B,C are
-  # obscure return values for weekValidation
-
-  def weekValidation
-    weeksToValidate = weekCount
-    valText = ""
-    case weeksToValidate
-      when 0..4
-        valText = "A"
-      when 4..17,5
-         valText = "B"
-       else
-        valText = "C"
-    end
-    return valText;
-
-  end
-
-  # CodeReviewSS17: This method needs a better name at least but:
-  # the only thing it seems to do is avoid translation
-  # for activeadmin. Why doesn't that work?
-  # Having a workaround with literal texts in the model
-  # is not a good solution
-  # also, duplicated code, see weekValidation
-
-  def weekValidationActAdm
-    weeksToValidate = weekCount
-    valText = ""
-    case weeksToValidate
-      when 0..4
-        valText = "Intership is less than 4 weeks"
-      when 4..17,5
-         valText = "Internship needs manual validation"
-       else
-        valText = "Internship is long enough"
-    end
-    return valText;
-  end
-
+  
    # CodeReviewSS17
    # CSV is a view and should not be in the model.
    def self.to_csv

--- a/app/models/internship.rb
+++ b/app/models/internship.rb
@@ -1,4 +1,5 @@
 require 'date'
+require 'time'
 class Internship < ActiveRecord::Base
 
   attr_accessible :attachments_attributes, :living_costs, :orientation_id, :salary, :working_hours, :programming_language_ids, :internship_rating_id,

--- a/app/models/internship.rb
+++ b/app/models/internship.rb
@@ -60,6 +60,11 @@ class Internship < ActiveRecord::Base
     end
   end
 
+  def returnDays
+    days = (self[:end_date] - self[:start_date]).to_i
+    return days;
+  end  
+
   def weekCount
     days = (self[:end_date] - self[:start_date]).to_i
     weeks = days/7

--- a/app/models/internship.rb
+++ b/app/models/internship.rb
@@ -66,7 +66,7 @@ class Internship < ActiveRecord::Base
   end  
 
   def weekCount
-    days = (self[:end_date] - self[:start_date]).to_i
+    days = returnDays
     weeks = days/7
     return weeks
   end

--- a/app/models/internship.rb
+++ b/app/models/internship.rb
@@ -59,7 +59,7 @@ class Internship < ActiveRecord::Base
   after_save do
      @duration = nil
   end
-  
+
    # CodeReviewSS17
    # CSV is a view and should not be in the model.
    def self.to_csv

--- a/app/models/internship_duration.rb
+++ b/app/models/internship_duration.rb
@@ -1,0 +1,44 @@
+class InternshipDuration
+
+  attr_accessor :start_date, :end_date, :days, :weeks, :validation
+
+  def initialize(internship)
+    if internship.start_date && internship.end_date
+      @start_date = internship.start_date
+      d = internship.end_date
+      @end_date = d.friday? ? d+3 : d
+      @days = @end_date - @start_date
+      @weeks = @days.to_f/7
+      @validation = do_validation(@weeks)
+    else
+      @days = @weeks = 0
+      @validation = :date_missing
+    end
+  end
+
+  def do_validation(weeks)
+    case
+      when weeks < 4
+        :too_short
+      when weeks < 19
+        :ok_for_part
+      else
+        :ok
+    end
+  end
+
+  #TBD this mapping needs to go to the translation, depends on I18n working for ActiveAdmin
+
+  def weekValidation
+    { too_short: "notLongEnough",
+      ok_for_part: "partInternship",
+      ok: "longEnough"}[validation]
+  end
+
+  def weekValidationActAdm
+    {too_short: "Intership is less than 4 weeks",
+       ok_for_part: "if internship is a part internship it's valid",
+       ok: "Internship is long enough"}[validation]
+  end
+
+end

--- a/app/views/internships/show.html.erb
+++ b/app/views/internships/show.html.erb
@@ -191,12 +191,12 @@
     <div class="span3" id="intern-title">
       <%= t "internships.attributes.weekValidation" %></div>
       <div class="span8" id="intern-box">
-        <% if @internship.weekValidation == "A" %>
-        <%= t "internships.attributes.weekVal.optionA"%>
-        <% elsif @internship.weekValidation == "B"  %>
-        <%= t "internships.attributes.weekVal.optionB"%> 
+        <% if @internship.weekValidation == "notLongEnough" %>
+        <%= t "internships.attributes.weekVal.notLongEnough"%>
+        <% elsif @internship.weekValidation == "partInternship"  %>
+        <%= t "internships.attributes.weekVal.partInternship"%> 
         <% else %>
-        <%= t "internships.attributes.weekVal.optionC"%> 
+        <%= t "internships.attributes.weekVal.longEnough"%> 
         <% end %>
       </div>    
     </div>

--- a/app/views/internships/show.html.erb
+++ b/app/views/internships/show.html.erb
@@ -146,7 +146,7 @@
        </div>
      </div>
    </div>
- </div> 
+ </div>
 
  <div class="row-fluid" id="row-intern">
   <div class="span12">
@@ -158,7 +158,7 @@
      </div>
    </div>
  </div>
-</div> 
+</div>
 </div>
 
 <div class="row-fluid" id="row-intern">
@@ -167,7 +167,7 @@
     <div class="span3" id="intern-title">
       <%= t "internships.attributes.amoutOfDays" %></div>
       <div class="span8" id="intern-box">
-       <%= @internship.returnDays %>
+       <%= @internship.duration.days %>
      </div>
    </div>
  </div>
@@ -179,7 +179,7 @@
     <div class="span3" id="intern-title">
       <%= t "internships.attributes.amountOfWeeks" %></div>
       <div class="span8" id="intern-box">
-       <%= @internship.weekCount %>
+       <%= @internship.duration.weeks %>
      </div>
    </div>
  </div>
@@ -191,21 +191,23 @@
     <div class="span3" id="intern-title">
       <%= t "internships.attributes.weekValidation" %></div>
       <div class="span8" id="intern-box">
-        <% if @internship.weekValidation == "notLongEnough" %>
+        <% #tbd ... wtf.the mapping of the mapping of the mapping in all the wrong places.
+
+        if @internship.duration.weekValidation == "notLongEnough" %>
         <%= t "internships.attributes.weekVal.notLongEnough"%>
-        <% elsif @internship.weekValidation == "partInternship"  %>
-        <%= t "internships.attributes.weekVal.partInternship"%> 
-        <% else %>
-        <%= t "internships.attributes.weekVal.longEnough"%> 
+        <% elsif @internship.duration.weekValidation == "partInternship"  %>
+        <%= t "internships.attributes.weekVal.partInternship"%>
+        <% else # tbd ... wtf ... and here comes core business logic in the view...%>
+        <%= t "internships.attributes.weekVal.longEnough"%>
         <% end %>
-      </div>    
+      </div>
     </div>
   </div>
-</div>  
+</div>
 
 <div id="edit">
  <%= link_to({:controller => :internships, :action => :edit, :id => @internship.id}, class: "btn btn-danger") do %>
- <i class = "icon-2x icon-large icon-white"> <%= t("buttons.edit") %> </i> 
+ <i class = "icon-2x icon-large icon-white"> <%= t("buttons.edit") %> </i>
  <% end %>
 
  <div id="favorite">
@@ -418,7 +420,7 @@
     <div id="company-title-text">
       <%= @company.main_language %>
     </div>
-    
+
     <% if @other_internships.any? %>
     <div id="company-title">
       <%= t("internships.others")  %>
@@ -437,4 +439,3 @@
   </div>
 </div>
 </div>
-

--- a/app/views/internships/show.html.erb
+++ b/app/views/internships/show.html.erb
@@ -165,6 +165,18 @@
   <div class="span12">
    <div class="row" id="row2-intern">
     <div class="span3" id="intern-title">
+      <%= t "internships.attributes.amoutOfDays" %></div>
+      <div class="span8" id="intern-box">
+       <%= @internship.returnDays %>
+     </div>
+   </div>
+ </div>
+</div>
+
+<div class="row-fluid" id="row-intern">
+  <div class="span12">
+   <div class="row" id="row2-intern">
+    <div class="span3" id="intern-title">
       <%= t "internships.attributes.amountOfWeeks" %></div>
       <div class="span8" id="intern-box">
        <%= @internship.weekCount %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -341,6 +341,7 @@ de:
       recommend: "Empfehlung"
       internship_report: "Praktikumsbericht"
       amountOfWeeks: "Anzahl der Wochen"
+      amoutOfDays: "Anzahl der Tage"
       weekValidation: "Validität"
       weekVal:
         optionA: "Die Praktikumsdauer ist kleiner als 4 Wochen"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -344,9 +344,9 @@ de:
       amoutOfDays: "Anzahl der Tage"
       weekValidation: "Validität"
       weekVal:
-        optionA: "Die Praktikumsdauer ist kleiner als 4 Wochen"
-        optionB: "Die Praktikumsdauer benötigt manuelle Nachberechnung"
-        optionC: "Die Praktikumsdauer ist ausreichend"
+        notLongEnough: "Die Praktikumsdauer ist kleiner als 4 Wochen"
+        partInternship: "Wenn das Praktikum ein Teilpraktikum ist, ist es valide"
+        longEnough: "Die Praktikumsdauer ist ausreichend"
 
 
   users:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -208,9 +208,9 @@ en:
       amoutOfDays: "The amount of days"
       weekValidation: "Validation status"
       weekVal:
-        optionA: "Intership is less than 4 weeks"
-        optionB: "Internship needs manual validation"
-        optionC: "Internship is long enough"  
+        notLongEnough: "Intership is less than 4 weeks"
+        partInternship: "If internship is a part internship it's valid"
+        longEnough: "Internship is long enough"  
 
 
   users:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -205,6 +205,7 @@ en:
       recommend: "Recommendation"
       internship_report: "Internship Report"
       amountOfWeeks: "Total amount of weeks"
+      amoutOfDays: "The amount of days"
       weekValidation: "Validation status"
       weekVal:
         optionA: "Intership is less than 4 weeks"

--- a/spec/models/internship_duration_spec.rb
+++ b/spec/models/internship_duration_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe InternshipDuration, :type => :model do
+  InternshipDummy = Struct.new(:start_date,:end_date)
+
+  describe "sets end_date" do
+    it 'to the next monday if it was a friday' do
+      id = InternshipDummy.new(Date.new(2017,10,9), Date.new(2017,10,13))
+      duration = InternshipDuration.new(id)
+      expect(duration.end_date).to eq(Date.new(2017,10,16))
+    end
+    it 'to actual date for other weekdays than friday' do
+      id = InternshipDummy.new(Date.new(2017,10,9), Date.new(2017,10,12))
+      duration = InternshipDuration.new(id)
+      expect(duration.end_date).to eq(Date.new(2017,10,12))
+    end
+  end
+
+  context "for an internship with 2 weeks" do
+    before :each do
+      id = InternshipDummy.new(Date.new(2017,10,9), Date.new(2017,10,20))
+      @duration = InternshipDuration.new(id)
+    end
+    it "weeks are computed correctly" do
+      expect(@duration.weeks).to eq(2)
+    end
+    it "validation marker is set correctly" do
+      expect(@duration.validation).to eq(:too_short)
+    end
+  end
+
+  context "for an internship with 7 weeks" do
+    before :each do
+      id = InternshipDummy.new(Date.new(2017,10,2), Date.new(2017,11,17))
+      @duration = InternshipDuration.new(id)
+    end
+    it "weeks are computed correctly" do
+      expect(@duration.weeks).to eq(7)
+    end
+    it "validation marker is set correctly" do
+      expect(@duration.validation).to eq(:ok_for_part)
+    end
+  end
+
+  context "for an internship with exactly 19 weeks" do
+    before :each do
+      id = InternshipDummy.new(Date.new(2017,10,2), Date.new(2018,2,9))
+      @duration = InternshipDuration.new(id)
+    end
+    it "weeks are computed correctly" do
+      expect(@duration.weeks).to eq(19)
+    end
+    it "validation marker is set correctly" do
+      expect(@duration.validation).to eq(:ok)
+    end
+  end
+
+  context "for an internship with more than 19 weeks" do
+    before :each do
+      id = InternshipDummy.new(Date.new(2017,10,2), Date.new(2018,3,7))
+      @duration = InternshipDuration.new(id)
+    end
+    it "weeks are computed correctly" do
+      expect(@duration.weeks).to eq(22.285714285714285)
+    end
+    it "validation marker is set correctly" do
+      expect(@duration.validation).to eq(:ok)
+    end
+  end
+
+  context "for an internship without an end_date" do
+    before :each do
+      id = InternshipDummy.new(Date.new(2017,10,2), nil)
+      @duration = InternshipDuration.new(id)
+    end
+    it "weeks are computed correctly" do
+      expect(@duration.weeks).to eq(0)
+    end
+    it "validation marker is set correctly" do
+      expect(@duration.validation).to eq(:date_missing)
+    end
+  end
+
+  context "for an internship without an start_date" do
+    before :each do
+      id = InternshipDummy.new(nil, Date.new(2017,10,2))
+      @duration = InternshipDuration.new(id)
+    end
+    it "weeks are computed correctly" do
+      expect(@duration.weeks).to eq(0)
+    end
+    it "validation marker is set correctly" do
+      expect(@duration.validation).to eq(:date_missing)
+    end
+  end
+
+  context "for an internship without any dates" do
+    before :each do
+      id = InternshipDummy.new(nil, nil)
+      @duration = InternshipDuration.new(id)
+    end
+    it "weeks are computed correctly" do
+      expect(@duration.weeks).to eq(0)
+    end
+    it "validation marker is set correctly" do
+      expect(@duration.validation).to eq(:date_missing)
+    end
+  end
+
+
+#  row ('weekCount') {ad.duration.weeks}
+#  row ('weekValidation') {ad.duration.weekValidationActAdm}
+end

--- a/spec/models/internship_spec.rb
+++ b/spec/models/internship_spec.rb
@@ -54,15 +54,4 @@ RSpec.describe Internship, :type => :model do
     end
   end
 
-  describe "#duration" do
-    it 'should return the correct internship duration in weeks' do
-    expect(internship.weekCount).to eq(1)
-    end
-  end 
-
-  describe "#weekValidation" do
-  it 'should return the correct string according to the week count' do
-    expect(internship.weekValidation).to eq("notLongEnough")
-  end 
 end
-end 

--- a/spec/models/internship_spec.rb
+++ b/spec/models/internship_spec.rb
@@ -62,8 +62,22 @@ RSpec.describe Internship, :type => :model do
 
   describe "#weekValidation" do
   it 'should return the correct string according to the week count' do
+    internship.weekCount = 1
     expect(internship.weekValidation).to eq("notLongEnough")
+  end 
+end
+
+describe "#weekValidation" do
+  it 'should return the correct string according to the week count' do
+    internship.weekCount = 16
+    expect(internship.weekValidation).to eq("partInternship")
   end 
 end 
 
+describe "#weekValidation" do
+  it 'should return the correct string according to the week count' do
+    internship.weekCount = 21
+    expect(internship.weekValidation).to eq("longEnough")
+  end 
+end
 end 

--- a/spec/models/internship_spec.rb
+++ b/spec/models/internship_spec.rb
@@ -62,22 +62,7 @@ RSpec.describe Internship, :type => :model do
 
   describe "#weekValidation" do
   it 'should return the correct string according to the week count' do
-    internship.weekCount = 1
     expect(internship.weekValidation).to eq("notLongEnough")
-  end 
-end
-
-describe "#weekValidation" do
-  it 'should return the correct string according to the week count' do
-    internship.weekCount = 16
-    expect(internship.weekValidation).to eq("partInternship")
-  end 
-end 
-
-describe "#weekValidation" do
-  it 'should return the correct string according to the week count' do
-    internship.weekCount = 21
-    expect(internship.weekValidation).to eq("longEnough")
   end 
 end
 end 

--- a/spec/models/internship_spec.rb
+++ b/spec/models/internship_spec.rb
@@ -54,15 +54,15 @@ RSpec.describe Internship, :type => :model do
     end
   end
 
-    describe "#duration" do
-    it 'should return the correct internship duration in weeks'do
+  describe "#duration" do
+    it 'should return the correct internship duration in weeks' do
     expect(internship.weekCount).to eq(1)
     end
   end 
 
   describe "#weekValidation" do
   it 'should return the correct string according to the week count' do
-    expect(internship.weekValidation).to eq("A")
+    expect(internship.weekValidation).to eq("notLongEnough")
   end 
 end 
 


### PR DESCRIPTION
-validate if starting day is a monday (130 days rule)
-rename options of duration of internship: either its too short or its a part-internship or the duration of the internship is valid as a " full " internship
- show days of internship in internship view